### PR TITLE
Fix Python 3 compatibility issue

### DIFF
--- a/src/v20/pricing.py
+++ b/src/v20/pricing.py
@@ -606,7 +606,7 @@ class EntitySpec(object):
                 self.ctx = ctx
 
             def __call__(self, line):
-                j = json.loads(line)
+                j = json.loads(line.decode('utf-8'))
 
                 type = j.get("type")
 


### PR DESCRIPTION
Content needs to be decoded before `json.loads()` as `iter_lines()` returns `bytes`
in Python 3. In Python 2 str has a split personality. It's both `bytes` and ascii text. 
So it will not break backward compatibility.
