### PR TITLE
Adding pyyaml package to install_requires

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -32,7 +32,7 @@ def main():
         "author_email": "api@oanda.com",
         "url": "https://github.com/oanda/v20-python",
         "license": "MIT",
-        "install_requires": ['requests', 'ujson'],
+        "install_requires": ['requests', 'ujson', 'pyyaml'],
         "packages": ["v20"],
         "data_files": [('', ['LICENSE.txt', 'ChangeLog'])],
         "platforms": ["any"],


### PR DESCRIPTION
It's missing but required:
https://github.com/oanda/v20-python/blob/master/src/v20/base_entity.py#L3